### PR TITLE
bug fix for node 0.6+

### DIFF
--- a/views/articles/article_list.jade
+++ b/views/articles/article_list.jade
@@ -1,8 +1,8 @@
 - if(lastInCollection)
-  - class = 'last'
+  - clazz = 'last'
 - else
-  - class = ''
-div(class="article #{class}")
+  - clazz = ''
+div(class="article #{clazz}")
   div.article_title
     a(href='/article/'+article._id, title=article.title) #{article.title}
   div.article_body


### PR DESCRIPTION
fixes the bug produced when running the demo in node 0.6+ "Unexpected reserved word"

```
Sorry, something went wrong. Probably one of our "genius" programmers made a boo-boo! :P

SyntaxError: /Users/jay/github/forks/nodejs-express-mongoose-demo/views/articles/index.jade:7
    5| div#articles
    6|   - if(articles.length)
  > 7|     != partial('article_list', {collection : articles, as : 'article'})
    8|   - else
    9|     #no-results No articles found. Create one
    10|       a(href="/articles/new") here

Unexpected reserved word
    at Object.Function (unknown source)
    at Object.compile (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/jade/lib/jade.js:161:8)
    at Function.compile (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:65:33)
    at ServerResponse._render (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:414:18)
    at ServerResponse.render (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:315:17)
    at render (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:184:16)
    at renderPartial (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:204:16)
    at Object.partial (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/express/lib/view.js:409:12)
    at eval at  (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/jade/lib/jade.js:161:8)
    at Object. (/Users/jay/github/forks/nodejs-express-mongoose-demo/node_modules/jade/lib/jade.js:166:12)
```
