### PR TITLE
Add a common section to the config

### DIFF
--- a/app/views/includes/footer.jade
+++ b/app/views/includes/footer.jade
@@ -1,0 +1,5 @@
+.footer
+  hr
+  !=common.appName
+  |  &copy; 
+  a(href="#{common.company_url}") #{common.company}

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -1,10 +1,16 @@
-
+var common = {
+    appName: 'Node.js Express Mongoose Demo'
+  , company: 'Company'
+  , company_url: 'http://example.com'
+  
+}
 module.exports = {
     development: {
       root: require('path').normalize(__dirname + '/..'),
       app: {
-        name: 'Nodejs Express Mongoose Demo'
+        name: common.appName
       },
+      common: common,
       db: 'mongodb://localhost/noobjs_dev',
       facebook: {
           clientID: "APP_ID"

--- a/config/express.js
+++ b/config/express.js
@@ -49,6 +49,9 @@ module.exports = function (app, config, passport) {
     // connect flash for flash messages
     app.use(flash())
 
+    //add commons to template. accessed by common.item
+    app.locals({common: config.common})
+
     // use passport session
     app.use(passport.initialize())
     app.use(passport.session())

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -46,3 +46,7 @@ a.tag {
 .error {
   color: #FF2602;
 }
+
+.footer {
+  margin: 25px;
+}


### PR DESCRIPTION
- some config settings are the same for all modes of running app
- templates often need these, so they'll be accessable in all templates with common.<name>
- added an example to the footer
