### PR TITLE
Sample variants seemed to be corrupted, these values work better

### DIFF
--- a/config/imager.example.js
+++ b/config/imager.example.js
@@ -2,13 +2,13 @@ module.exports = {
   variants: {
     article: {
       resize: {
-        detail: "x440"
+        detail: "800x600"
       },
       crop: {
-        thumb: "16000@"
+        thumb: "200x200"
       },
       resizeAndCrop: {
-        mini: {resize: "63504@", crop: "252x210"}
+        mini: {resize: "200x150", crop: "100x100"}
       }
     },
 


### PR DESCRIPTION
I was using the example file as my config/imager.js file, and seeing thousands of files get created in my /tmp file for the thumbnail image, and the server was hanging.  These 'sane' parameters fixed the issue for me.
