### PR TITLE
404 error adding comments

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -1,4 +1,3 @@
-
 /*!
  * Module dependencies.
  */
@@ -93,6 +92,7 @@ module.exports = function (app, passport) {
   // comment routes
   var comments = require('../app/controllers/comments')
   app.post('/articles/:id/comments', auth.requiresLogin, comments.create)
+  app.get('/articles/:id/comments', auth.requiresLogin, comments.create)
 
   // tag routes
   var tags = require('../app/controllers/tags')


### PR DESCRIPTION
steps to reproduce:
1. add comments without login
2. system prompts login
3. system looks for a get route, and throws 404 error.
