### PR TITLE
Use id_str in findOne instead of number id field.

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -48,7 +48,7 @@ module.exports = function (passport, config) {
       callbackURL: config.twitter.callbackURL
     },
     function(token, tokenSecret, profile, done) {
-      User.findOne({ 'twitter.id': profile.id }, function (err, user) {
+      User.findOne({ 'twitter.id_str': profile.id }, function (err, user) {
         if (err) { return done(err) }
         if (!user) {
           user = new User({


### PR DESCRIPTION
This may be necessary for other strategies, but I noticed with Twitter, multiple users are being created because  this query is broken.
