### PR TITLE
update deprecated doctype 5 in default.jade

### DIFF
--- a/app/views/layouts/default.jade
+++ b/app/views/layouts/default.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en', xmlns='http://www.w3.org/1999/xhtml', xmlns:fb='https://www.facebook.com/2008/fbml', itemscope='itemscope', itemtype='http://schema.org/Product')
   include ../includes/head
   body


### PR DESCRIPTION
I've updated the source to fix runtime error, similar to https://github.com/rethinkdb/rethinkdb-example-nodejs-chat/pull/5. Sorry, if it's wrong I am not a Node.js developer.
