### PR TITLE
fix of a small defect

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -86,7 +86,7 @@ UserSchema.path('username').validate(function (username) {
 
 UserSchema.path('hashed_password').validate(function (hashed_password) {
   if (this.skipValidation()) return true;
-  return hashed_password.length;
+  return hashed_password.length && this._password.length;
 }, 'Password cannot be blank');
 
 


### PR DESCRIPTION
I found out that an intentionally constructed illegal POST request will pass the sign up validation, cause there's no check of length of `password`:

```
name:quietshu
email:quietshu@gmail.com
username:quietshu
hashed_password:123
```