### PR TITLE
replace util._extend with Object.assign()

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -5,7 +5,6 @@
  */
 
 const path = require('path');
-const extend = require('util')._extend;
 
 const development = require('./env/development');
 const test = require('./env/test');
@@ -30,7 +29,7 @@ const defaults = {
  */
 
 module.exports = {
-  development: extend(development, defaults),
-  test: extend(test, defaults),
-  production: extend(production, defaults)
+  development: Object.assign(development, defaults),
+  test: Object.assign(test, defaults),
+  production: Object.assign(production, defaults)
 }[process.env.NODE_ENV || 'development'];


### PR DESCRIPTION
util._extend is deprecated and should not be used in new code as mentioned in Node.js Documentation, replace it by Javascript similar built-in functionality Object.assign().